### PR TITLE
Fix CollectionView.extend

### DIFF
--- a/ampersand-collection-view.js
+++ b/ampersand-collection-view.js
@@ -142,6 +142,6 @@ _.extend(CollectionView.prototype, BBEvents, {
     }
 });
 
-CollectionView.prototype.extend = ampExtend;
+CollectionView.extend = ampExtend;
 
 module.exports = CollectionView;


### PR DESCRIPTION
The extend function was in the prototype instead of the class.
