### PR TITLE
add phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ampersand-view": "^7.0.0",
     "browserify": "^4.2.3",
     "jshint": "~2.5.1",
+    "phantomjs": "^1.9.7-15",
     "precommit-hook": "~1.0.2",
     "run-browser": "~1.3.1",
     "tap-spec": "^0.2.0",


### PR DESCRIPTION
Required as a dev dependency so tests will run if it is not installed globally.
