### PR TITLE
Empty view with parent

### DIFF
--- a/ampersand-collection-view.js
+++ b/ampersand-collection-view.js
@@ -135,7 +135,7 @@ _.extend(CollectionView.prototype, BBEvents, {
     },
     _renderEmptyView: function() {
         if (this.emptyView && !this.renderedEmptyView) {
-            var view = this.renderedEmptyView = new this.emptyView();
+            var view = this.renderedEmptyView = new this.emptyView({parent: this});
             this.el.appendChild(view.render().el);
         }
     },

--- a/ampersand-collection-view.js
+++ b/ampersand-collection-view.js
@@ -41,9 +41,8 @@ _.extend(CollectionView.prototype, BBEvents, {
         });
     },
     _createViewForModel: function (model, renderOpts) {
-        var view = new this.view(_({model: model, collection: this.collection}).extend(this.viewOptions));
+        var view = new this.view(_({model: model, collection: this.collection}).extend(this.viewOptions, {parent: this}));
         this.views.push(view);
-        view.parent = this;
         view.renderedByParentView = true;
         view.render(renderOpts);
         return view;

--- a/test/index.js
+++ b/test/index.js
@@ -524,6 +524,29 @@ test('should render emptyView after adding an item to an empty collection and re
     t.end();
 });
 
+test('should set `parent` on child views', function(t) {
+    t.plan(data.length * 2);
+
+    var TestItemView = ItemView.extend({
+        initialize: function(attrs) {
+            ItemView.prototype.initialize.call(this, attrs);
+            t.equal(this.parent, cv);
+        }
+    });
+    var coll = new Collection(data);
+    var div = document.createElement('div');
+    var cv = new CollectionView({
+        el: div,
+        collection: coll,
+        view: TestItemView
+    });
+
+    cv.render();
+    cv.views.forEach(function(view) {
+      t.equal(view.parent, cv);
+    });
+});
+
 test('should set `parent` on emptyView', function(t) {
     t.plan(2);
 

--- a/test/index.js
+++ b/test/index.js
@@ -523,3 +523,25 @@ test('should render emptyView after adding an item to an empty collection and re
     t.equal(view.el.innerHTML, '<section>tumbleweed...</section>');
     t.end();
 });
+
+test('should set `parent` on emptyView', function(t) {
+    t.plan(2);
+
+    var TestEmptyView = EmptyView.extend({
+        initialize: function(attrs) {
+            EmptyView.prototype.initialize.call(this, attrs);
+            t.equal(this.parent, cv);
+        }
+    });
+    var coll = new Collection([]);
+    var div = document.createElement('div');
+    var cv = new CollectionView({
+        el: div,
+        collection: coll,
+        view: ItemView,
+        emptyView: TestEmptyView
+    });
+
+    cv.render();
+    t.equal(cv.renderedEmptyView.parent, cv);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -525,7 +525,7 @@ test('should render emptyView after adding an item to an empty collection and re
 });
 
 test('should set `parent` on child views', function(t) {
-    t.plan(data.length * 2);
+    t.plan(6);
 
     var TestItemView = ItemView.extend({
         initialize: function(attrs) {


### PR DESCRIPTION
Hi there,

The `parent` property is not set on `emptyView`s like with child views, so I had to use this workaround:

```javascript
var myCollectionView = this.renderCollection(
  myCollection,
  MyView,
  this.queryByHook('myView'),
  {
    emptyView: function () {
      return new MyEmptyView({
        parent: myCollectionView
      });
    }
  }
);
```

For the sake of consistency it would be great if the `parent` property would be set automatically for `emptyView`s. So I only had to write:

```javascript
var myCollectionView = this.renderCollection(
  myCollection,
  MyView,
  this.queryByHook('myView'),
  {
    emptyView: MyEmptyView
  }
);
```

That's what this PR is all about.