### PR TITLE
Adding event triggers to add/remove views

### DIFF
--- a/ampersand-collection-view.js
+++ b/ampersand-collection-view.js
@@ -70,7 +70,7 @@ assign(CollectionView.prototype, Events, {
         } else {
             this._insertViewAtIndex(view);
         }
-        this.trigger('addViewForModel', view);
+        this.trigger('model-view:added', view);
     },
     _insertViewAtIndex: function (view) {
         if (!view.insertSelf) {
@@ -118,7 +118,7 @@ assign(CollectionView.prototype, Events, {
                 this._renderEmptyView();
             }
         }
-        this.trigger('removeViewForModel', view);
+        this.trigger('model-view:removed', view);
     },
     _removeView: function (view) {
         if (view.animateRemove) {

--- a/ampersand-collection-view.js
+++ b/ampersand-collection-view.js
@@ -70,6 +70,7 @@ assign(CollectionView.prototype, Events, {
         } else {
             this._insertViewAtIndex(view);
         }
+        this.trigger('addViewForModel', view);
     },
     _insertViewAtIndex: function (view) {
         if (!view.insertSelf) {
@@ -117,6 +118,7 @@ assign(CollectionView.prototype, Events, {
                 this._renderEmptyView();
             }
         }
+        this.trigger('removeViewForModel', view);
     },
     _removeView: function (view) {
         if (view.animateRemove) {

--- a/test/index.js
+++ b/test/index.js
@@ -568,3 +568,43 @@ test('should set `parent` on emptyView', function(t) {
     cv.render();
     t.equal(cv.renderedEmptyView.parent, cv);
 });
+
+test('adding to collection should trigger addViewForModel', function (t) {
+    var coll = new Collection(data);
+    var div = document.createElement('div');
+    var cv = new CollectionView({
+        el: div,
+        collection: coll,
+        view: ItemView
+    });
+    cv.render();
+    var firstView = cv.views[0];
+    var firstEl = firstView && firstView.el;
+
+    cv.on('addViewForModel', function (view) {
+        t.equal(view.model.name, 'henrik');
+        t.end();
+    });
+
+    coll.add({name: 'henrik', id: 4});
+});
+
+test('removing from collection should trigger removeViewForModel', function (t) {
+    var coll = new Collection(data);
+    var div = document.createElement('div');
+    var cv = new CollectionView({
+        el: div,
+        collection: coll,
+        view: ItemView
+    });
+    cv.render();
+    t.equal(cv.views.length, 3);
+    var firstView = cv.views[0];
+
+    cv.on('removeViewForModel', function (view) {
+        t.equal(view.model.name, firstView.model.name);
+        t.end();
+    });
+
+    coll.remove(coll.at(0));
+});

--- a/test/index.js
+++ b/test/index.js
@@ -578,8 +578,6 @@ test('adding to collection should trigger addViewForModel', function (t) {
         view: ItemView
     });
     cv.render();
-    var firstView = cv.views[0];
-    var firstEl = firstView && firstView.el;
 
     cv.on('addViewForModel', function (view) {
         t.equal(view.model.name, 'henrik');

--- a/test/index.js
+++ b/test/index.js
@@ -579,7 +579,7 @@ test('adding to collection should trigger addViewForModel after appending', func
     });
     cv.render();
 
-    cv.on('addViewForModel', function (view) {
+    cv.on('model-view:added', function (view) {
         t.equal(view.model.name, 'henrik');
         t.ok(/henrik/.test(cv.el.textContent), 
             'expect ' + cv.el.textContent + ' to match /henrik/');
@@ -602,7 +602,7 @@ test('removing from collection should trigger removeViewForModel after removal',
     var firstView = cv.views[0];
     var firstNamePattern = new RegExp(firstView.model.name); 
 
-    cv.on('removeViewForModel', function (view) {
+    cv.on('model-view:removed', function (view) {
         t.equal(view.model.name, firstView.model.name);
         t.notOk(firstNamePattern.test(cv.el.textContent), 
             'expect ' + cv.el.textContent + ' not to match ' + firstNamePattern);

--- a/test/index.js
+++ b/test/index.js
@@ -569,7 +569,7 @@ test('should set `parent` on emptyView', function(t) {
     t.equal(cv.renderedEmptyView.parent, cv);
 });
 
-test('adding to collection should trigger addViewForModel', function (t) {
+test('adding to collection should trigger addViewForModel after appending', function (t) {
     var coll = new Collection(data);
     var div = document.createElement('div');
     var cv = new CollectionView({
@@ -581,13 +581,15 @@ test('adding to collection should trigger addViewForModel', function (t) {
 
     cv.on('addViewForModel', function (view) {
         t.equal(view.model.name, 'henrik');
+        t.ok(/henrik/.test(cv.el.textContent), 
+            'expect ' + cv.el.textContent + ' to match /henrik/');
         t.end();
     });
 
     coll.add({name: 'henrik', id: 4});
 });
 
-test('removing from collection should trigger removeViewForModel', function (t) {
+test('removing from collection should trigger removeViewForModel after removal', function (t) {
     var coll = new Collection(data);
     var div = document.createElement('div');
     var cv = new CollectionView({
@@ -598,9 +600,12 @@ test('removing from collection should trigger removeViewForModel', function (t) 
     cv.render();
     t.equal(cv.views.length, 3);
     var firstView = cv.views[0];
+    var firstNamePattern = new RegExp(firstView.model.name); 
 
     cv.on('removeViewForModel', function (view) {
         t.equal(view.model.name, firstView.model.name);
+        t.notOk(firstNamePattern.test(cv.el.textContent), 
+            'expect ' + cv.el.textContent + ' not to match ' + firstNamePattern);
         t.end();
     });
 


### PR DESCRIPTION
Motivation: I've recently had to deal with a third party media API that accepts an `id` string as an input for the element in which to render the media, which means I need to be able to guarantee that the element is in the DOM before I pass it through. Custom events is the cleanest way to do this as things stand.

I'm putting it here in case anyone else thinks it would make their lives easier more than anything else: it's mostly useful I'd guess for irritating edge cases like mine. 
